### PR TITLE
trigger CDK deploy on Lambda push action

### DIFF
--- a/.github/workflows/trigger-cdk-deploy.yaml
+++ b/.github/workflows/trigger-cdk-deploy.yaml
@@ -1,0 +1,19 @@
+name: Trigger CDK Deploy on Lambda Push
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger-cdk-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send dispatch event to CDK repo
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token ${{ secrets.CDK_DEPLOY_PAT }}" \
+            https://api.github.com/repos/abilliti-dev/abilliti-backend-cdk/dispatches \
+            -d '{"event_type":"lambda-updated"}'


### PR DESCRIPTION
Github workflow action to trigger a CDK deploy whenever Lambda is updated. CDK_DEPLOY_PAT has been added to this repo to give permissions to dispatch event